### PR TITLE
Add favicons to search results

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -236,7 +236,12 @@
                                 <div class="d-flex justify-content-between align-items-center">
                                     <div class="flex-grow-1 ms-3">
                                         {% if result.title %}  <!-- result.title ist der Titel -->
-                                            <a href="{{ result.url }}" target="_blank">{{ result.title }}</a>  <!-- result[0] ist die URL -->
+                                            <a href="{{ result.url }}" target="_blank">
+                                                {% if result.favicon %}
+                                                    <img src="{{ result.favicon }}" alt="Favicon" style="width: 16px; height: 16px; margin-right: 5px;">
+                                                {% endif %}
+                                                {{ result.title }}
+                                            </a>  <!-- result[0] ist die URL -->
                                         {% else %}
                                             <a href="{{ result.url }}" target="_blank"><em>No title available</em></a>
                                         {% endif %}


### PR DESCRIPTION
Add functionality to retrieve and display favicons for each search result.

* **app.py**
  - Import the `favicon` library.
  - Add a function `get_favicon_url` to retrieve favicons from URLs.
  - Implement caching for favicons to reduce loading time.
  - Modify the `search` function to include favicons in the results.

* **templates/search.html**
  - Add an `img` tag to display the favicon next to the title in the search results.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/search-engine/pull/3?shareId=69f3a341-9208-4303-a5eb-2938a3f06117).