### PR TITLE
Add website embedding to search results

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -294,6 +294,16 @@
         const modal = new bootstrap.Modal(document.getElementById('embeddedWebsiteModal'));
         modal.show();
     }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('.list-group-item').forEach(function (item) {
+            item.addEventListener('contextmenu', function (e) {
+                e.preventDefault();
+                const url = this.querySelector('a').href;
+                viewEmbeddedWebsite(url);
+            });
+        });
+    });
 </script>
 
             


### PR DESCRIPTION
Add right-click context menu to search results for website embedding.

* Add event listener to each search result item to handle right-click context menu.
* Remove "View Embedded" button from each search result.
* Update JavaScript to handle embedding of websites in the modal when right-clicked.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/search-engine/pull/4?shareId=7f698402-4a66-482f-b0d8-cc671cf57883).