### PR TITLE
Rename Docker image to search

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v2
+    - name: Log in to Docker Hub
+      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+      run: docker build . --file Dockerfile --tag search:$(date +%s)
+    - name: Push the Docker image
+      run: docker push search:$(date +%s)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://hub.docker.com/r/schbenedikt/search
 To build the Docker image, run the following command in the root directory of the repository:
 
 ```sh
-docker build -t search-engine .
+docker build -t search .
 ```
 
 ### Running the Docker Container
@@ -25,7 +25,7 @@ docker build -t search-engine .
 To run the Docker container, use the following command:
 
 ```sh
-docker run -p 5000:5000 search-engine
+docker run -p 5000:5000 search
 ```
 
 This will start the Flask application, and it will be accessible at `http://localhost:5000`.


### PR DESCRIPTION
Rename the Docker image to `search` in the workflow and README files.

* **Workflow Changes**
  - Change the Docker image tag from `my-image-name` to `search`.
  - Update the `actions/checkout` action to version 2.
  - Add a step to log in to Docker Hub using secrets.
  - Add a step to push the Docker image to Docker Hub.

* **README Changes**
  - Change the Docker image name in the build command to `search`.
  - Change the Docker image name in the run command to `search`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/search-engine/pull/7?shareId=e309f587-566c-4f8c-a7b3-1553b96c031b).