### PR TITLE
Upload Docker image to ghcr.io

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,9 +14,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Log in to Docker Hub
-      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+    - name: Log in to GitHub Container Registry
+      run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag search:$(date +%s)
+      run: docker build . --file Dockerfile --tag ghcr.io/${{ github.repository }}:$(date +%s)
     - name: Push the Docker image
-      run: docker push search:$(date +%s)
+      run: docker push ghcr.io/${{ github.repository }}:$(date +%s)


### PR DESCRIPTION
Update the GitHub Actions workflow to push the Docker image to GitHub Container Registry (ghcr.io).

* **Log in to GitHub Container Registry**
  - Replace Docker Hub login step with GitHub Container Registry login using `GHCR_TOKEN` secret.
* **Build and Push Docker Image**
  - Update the image tag to use `ghcr.io/${{ github.repository }}:$(date +%s)` instead of Docker Hub.
  - Modify the push step to push the image to `ghcr.io/${{ github.repository }}:$(date +%s)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/search-engine/pull/8?shareId=9798757f-198a-40df-a227-b247ca981759).