### PR TITLE
Fix Docker build by using lowercase repository name

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,6 +17,6 @@ jobs:
     - name: Log in to GitHub Container Registry
       run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag ghcr.io/${{ github.repository }}:$(date +%s)
+      run: docker build . --file Dockerfile --tag ghcr.io/${{ github.repository | toLowerCase }}:$(date +%s)
     - name: Push the Docker image
-      run: docker push ghcr.io/${{ github.repository }}:$(date +%s)
+      run: docker push ghcr.io/${{ github.repository | toLowerCase }}:$(date +%s)


### PR DESCRIPTION
Update the Docker build and push commands in the GitHub Actions workflow to use a lowercase repository name.

* Modify the `docker build` command to use a lowercase repository name in the `.github/workflows/docker-image.yml` file.
* Modify the `docker push` command to use a lowercase repository name in the `.github/workflows/docker-image.yml` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/search-engine/pull/9?shareId=3b4bedc2-b0c3-4a55-a19c-97b6d619233d).