### PR TITLE
Make Docker package public

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,3 +32,7 @@ jobs:
           context: .
           push: true
           tags: ghcr.io/schbenedikt/search-engine:latest
+
+      - name: Make Docker package public
+        run: |
+          gh api -X PATCH /user/packages/container/ghcr.io/schbenedikt/search-engine/visibility --field visibility=public

--- a/README.md
+++ b/README.md
@@ -29,3 +29,11 @@ docker run -p 5000:5000 ghcr.io/schbenedikt/search:latest
 ```
 
 This will start the Flask application, and it will be accessible at `http://localhost:5000`.
+
+### Pulling the Docker Image
+
+The Docker image is publicly accessible. To pull the Docker image from GitHub Container Registry, use the following command:
+
+```sh
+docker pull ghcr.io/schbenedikt/search:latest
+```


### PR DESCRIPTION
Make the Docker package public and update documentation.

* **README.md**
  - Add instructions to inform users that the Docker image is publicly accessible.
  - Add instructions on how to pull the Docker image from GitHub Container Registry.

* **.github/workflows/docker-image.yml**
  - Add a step to make the Docker package public after pushing the Docker image.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/search-engine/pull/11?shareId=73ab7a99-eae7-4ad1-a4cc-83d0f3216330).