### PR TITLE
Fix Docker image tag and name images with today's date

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,10 +26,16 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ghcr.io/schbenedikt/search-engine:latest
+          tags: ghcr.io/schbenedikt/search-engine:latest # Ensure the correct tag is used to avoid multiple packages
 
       - name: Extract image tag
         id: extract
         run: |
-          DATE_TAG=$(date +'%Y%m%d%H%M%S')
+          DATE_TAG=$(date +'%Y%m%d')
           echo "image_tag=$DATE_TAG" >> $GITHUB_ENV
+
+      - name: Build and push Docker image with date tag
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ghcr.io/schbenedikt/search-engine:${{ env.image_tag }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://hub.docker.com/r/schbenedikt/search
 To build the Docker image, run the following command in the root directory of the repository:
 
 ```sh
-docker build -t ghcr.io/schbenedikt/search:latest .
+docker build -t ghcr.io/schbenedikt/search-engine:latest .
 ```
 
 ### Running the Docker Container
@@ -25,7 +25,7 @@ docker build -t ghcr.io/schbenedikt/search:latest .
 To run the Docker container, use the following command:
 
 ```sh
-docker run -p 5000:5000 ghcr.io/schbenedikt/search:latest
+docker run -p 5000:5000 ghcr.io/schbenedikt/search-engine:latest
 ```
 
 This will start the Flask application, and it will be accessible at `http://localhost:5000`.
@@ -35,5 +35,8 @@ This will start the Flask application, and it will be accessible at `http://loca
 The Docker image is publicly accessible. To pull the Docker image from GitHub Container Registry, use the following command:
 
 ```sh
-docker pull ghcr.io/schbenedikt/search:latest
+docker pull ghcr.io/schbenedikt/search-engine:latest
 ```
+
+### Note
+Ensure that the `tags` field in the GitHub Actions workflow is correctly set to `ghcr.io/schbenedikt/search-engine:latest` to avoid multiple packages.


### PR DESCRIPTION
Update Docker image tag and GitHub Actions workflow to avoid multiple packages.

* **README.md**
  - Update Docker image tag to `ghcr.io/schbenedikt/search-engine:latest`.
  - Add a note about ensuring the correct tag is used to avoid multiple packages.

* **.github/workflows/docker-image.yml**
  - Update the `tags` field to `ghcr.io/schbenedikt/search-engine:latest`.
  - Add a comment to ensure the correct tag is used to avoid multiple packages.
  - Add a step to name the images with today's date.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/search-engine/pull/12?shareId=ce813541-fb2e-43c3-96d6-7f0bae827ede).