### PR TITLE
Fix Docker container to support multiple platforms

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           push: true
           tags: ghcr.io/schbenedikt/search-engine:latest # Ensure the correct tag is used to avoid multiple packages
+          platforms: linux/amd64,linux/arm64
 
       - name: Extract image tag
         id: extract
@@ -39,3 +40,4 @@ jobs:
         with:
           push: true
           tags: ghcr.io/schbenedikt/search-engine:${{ env.image_tag }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Add platform specification to Docker build-push-action to support multiple architectures.

* Modify `.github/workflows/docker-image.yml` to include `platforms: linux/amd64,linux/arm64` in the `docker/build-push-action` step to support multiple architectures.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/search-engine/pull/13?shareId=505f2faf-c191-41f6-a6ca-f18b30c2a90d).