### PR TITLE
Fix NLTK punkt resource error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,8 @@ COPY . /app
 # Install the dependencies from requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Download the 'punkt' resource
+RUN python -m nltk.downloader punkt
+
 # Set the entry point to run the Flask application
 CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "app:app"]

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ like_times = {}
 
 # Lade die Stop-Wörter für Englisch und Deutsch
 nltk.download('stopwords')
+nltk.download('punkt')
 stop_words = set(stopwords.words('english')).union(set(stopwords.words('german')))
 stemmer = PorterStemmer()
 


### PR DESCRIPTION
Add NLTK 'punkt' resource download to fix LookupError.

* **app.py**
  - Add `nltk.download('punkt')` after `nltk.download('stopwords')` to download the 'punkt' resource.

* **Dockerfile**
  - Add `RUN python -m nltk.downloader punkt` after `RUN pip install --no-cache-dir -r requirements.txt` to download the 'punkt' resource.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/search-engine/pull/15?shareId=c9d4e39b-0a32-4e33-9885-6feb525d7119).