### PR TITLE
Fix NLTK punkt_tab resource download issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,8 @@ COPY . /app
 # Install the dependencies from requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Download the 'punkt_tab' resource during the build process
+RUN python -m nltk.downloader punkt_tab
+
 # Set the entry point to run the Flask application
 CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "app:app"]

--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ like_times = {}
 # Lade die Stop-Wörter für Englisch und Deutsch
 nltk.download('stopwords')
 nltk.download('punkt')
+nltk.download('punkt_tab')
 stop_words = set(stopwords.words('english')).union(set(stopwords.words('german')))
 stemmer = PorterStemmer()
 


### PR DESCRIPTION
Add the download of the 'punkt_tab' resource to ensure it is available during runtime.

* **app.py**
  - Add `nltk.download('punkt_tab')` to download the 'punkt_tab' resource.

* **Dockerfile**
  - Add `RUN python -m nltk.downloader punkt_tab` to download the 'punkt_tab' resource during the build process.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/search-engine/pull/16?shareId=43167c7f-7db1-4ee0-995c-6fcb4f83db61).