### PR TITLE
Fix Docker startup issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ COPY . /app
 # Install the dependencies from requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Download the 'punkt_tab' resource during the build process
-RUN python -m nltk.downloader punkt_tab
+# Download the 'stopwords' resource during the build process
+RUN python -m nltk.downloader stopwords
 
 # Set the entry point to run the Flask application
 CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "app:app"]

--- a/app.py
+++ b/app.py
@@ -12,9 +12,7 @@ app = Flask(__name__)
 like_times = {}
 
 # Lade die Stop-Wörter für Englisch und Deutsch
-nltk.download('stopwords')
 nltk.download('punkt')
-nltk.download('punkt_tab')
 stop_words = set(stopwords.words('english')).union(set(stopwords.words('german')))
 stemmer = PorterStemmer()
 


### PR DESCRIPTION
Update `Dockerfile` and `app.py` to fix Docker container startup issues and ensure the website loads correctly.

* **Dockerfile**
  - Add a step to download the `stopwords` package during the build process.
  - Remove the `punkt_tab` download step as it is not needed.

* **app.py**
  - Remove the `nltk.download('stopwords')` line.
  - Remove the `nltk.download('punkt_tab')` line.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/search-engine/pull/17?shareId=aec68f33-5bc6-45f5-8899-a911d87806b3).