### PR TITLE
Fix NLTK LookupError by downloading 'punkt' resource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Download the 'stopwords' resource during the build process
 RUN python -m nltk.downloader stopwords
 
+# Download the 'punkt' resource during the build process
+RUN python -m nltk.downloader punkt
+
 # Add a health check to ensure the MongoDB connection is available before starting the Flask application
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget --spider http://localhost:5000/health || (echo "Datenbank nicht verfügbar, Anwendung nicht gestartet" && exit 1)
 

--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ like_times = {}
 
 # Lade die Stop-Wörter für Englisch und Deutsch
 nltk.download('stopwords')
+nltk.download('punkt')
 stop_words = set(stopwords.words('english')).union(set(stopwords.words('german')))
 stemmer = PorterStemmer()
 


### PR DESCRIPTION
Add NLTK 'punkt' resource download to resolve LookupError.

* **Dockerfile**: Add a command to download the 'punkt' resource during the build process.
* **app.py**: Add `nltk.download('punkt')` after the existing `nltk.download('stopwords')` command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/search-engine/pull/23?shareId=6056ff5a-ddfb-4609-aa6a-f9765e889f7d).