### PR TITLE
Typ-Feld verkleinert

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -133,7 +133,8 @@
     <div class="container">
         <form class="d-flex w-100" method="POST" action="/">
             <input id="search-input" class="form-control me-2 flex-grow-1 transparent-search" type="search" placeholder="Search" aria-label="Search" name="query" value="{{ request.args.get('query', '') }}">
-            <select class="form-select me-2" name="type" id="type-select">
+            <!-- Updated select element with reduced width -->
+            <select class="form-select me-2" name="type" id="type-select" style="max-width: 150px;">
                 <option value="">Alle</option>
                 {% for cat in categories %}
                     <option value="{{ cat }}" {% if cat == request.args.get('type', '') %} selected {% endif %}>


### PR DESCRIPTION
This pull request includes a small change to the `templates/search.html` file. The change updates the `select` element to have a reduced width by adding a `max-width` style property. 

* [`templates/search.html`](diffhunk://#diff-78ed6d575e1975d8bc028b059a6e8fc29bd4fe0d23e06028f63efec2a1427719L136-R137): Updated `select` element with reduced width by adding a `max-width: 150px;` style property.