### PR TITLE
Update Docker configuration to use port 5560

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN python -m nltk.downloader stopwords
 RUN python -m nltk.downloader punkt
 
 # Add a health check to ensure the MongoDB connection is available before starting the Flask application
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget --spider http://localhost:5000/health || (echo "Datenbank nicht verfügbar, Anwendung nicht gestartet" && exit 1)
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget --spider http://localhost:5560/health || (echo "Datenbank nicht verfügbar, Anwendung nicht gestartet" && exit 1)
 
 # Set the entry point to run the Flask application
-CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "app:app"]
+CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:5560", "app:app"]

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ docker build -t ghcr.io/schbenedikt/search-engine:latest .
 To run the Docker container, use the following command:
 
 ```sh
-docker run -p 5000:5000 ghcr.io/schbenedikt/search-engine:latest
+docker run -p 5560:5560 ghcr.io/schbenedikt/search-engine:latest
 ```
 
-This will start the Flask application using Gunicorn as the WSGI server, and it will be accessible at `http://localhost:5000`.
+This will start the Flask application using Gunicorn as the WSGI server, and it will be accessible at `http://localhost:5560`.
 
 ### Pulling the Docker Image
 
@@ -49,7 +49,7 @@ To run both the search engine and MongoDB containers using Docker Compose, use t
 docker-compose up
 ```
 
-This will start both containers and the Flask application will be accessible at `http://localhost:5000`.
+This will start both containers and the Flask application will be accessible at `http://localhost:5560`.
 
 ### Docker Compose File
 
@@ -64,7 +64,7 @@ services:
     depends_on:
       - mongodb
     ports:
-      - "5000:5000"
+      - "5560:5560"
 
   mongodb:
     image: mongo:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     depends_on:
       - mongodb
     ports:
-      - "5000:5000"
+      - "5560:5560"
     restart: always
 
   mongodb:


### PR DESCRIPTION
Update the Docker configuration to use port 5560 instead of 5000.

* **Dockerfile**
  - Change the health check URL to use port 5560.
  - Update the CMD instruction to start the Flask application on port 5560.

* **docker-compose.yml**
  - Update the ports section to map port 5560 instead of 5000.

* **README.md**
  - Update the Docker run command to use port 5560.
  - Update the Docker Compose instructions to reflect the new port 5560.
  - Modify the example `docker-compose.yml` file to use port 5560.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/search-engine/pull/27?shareId=4cea9c4b-a4aa-4ff1-b40e-587473f5c58c).