### PR TITLE
Add support for database authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,22 @@ services:
 volumes:
   mongo-data:
 ```
+
+### Database Configuration
+
+The `db_config.json` file is used to store the database configuration. Here is an example of the `db_config.json` file:
+
+```json
+[
+  {
+    "url": "mongodb://localhost:27017",
+    "name": "search_engine",
+    "username": "your_username",
+    "password": "your_password"
+  }
+]
+```
+
+### Settings Page
+
+The `settings.html` file has been updated to include fields for username and password. You can access the settings page at `http://localhost:5560/settings` to update the database configuration.

--- a/app.py
+++ b/app.py
@@ -31,7 +31,7 @@ def get_db_connection():
     if not connections:
         return None
     try:
-        client = MongoClient(connections[0]['url'])
+        client = MongoClient(connections[0]['url'], username=connections[0].get('username'), password=connections[0].get('password'))
         db = client[connections[0]['name']]
         # Stelle sicher, dass der Textindex erstellt wurde
         db['meta_data'].create_index([("title", TEXT), ("url", TEXT)])
@@ -46,7 +46,7 @@ def get_all_db_connections():
     dbs = []
     for conn in connections:
         try:
-            client = MongoClient(conn['url'])
+            client = MongoClient(conn['url'], username=conn.get('username'), password=conn.get('password'))
             db = client[conn['name']]
             db['meta_data'].create_index([("title", TEXT), ("url", TEXT)])
             dbs.append(db)
@@ -258,7 +258,7 @@ def suggest():
         print(f'Error: {e}')
         return jsonify({'suggestions': []})
 
-@app.route('/autocomplete', methods=['GET'])
+@app.route('/autocomplete', methods['GET'])
 def autocomplete():
     term = request.args.get('term')
     if (term):
@@ -310,6 +310,8 @@ def save_settings():
     data = request.get_json()
     db_url = data.get('db_url')
     db_name = data.get('db_name', 'search_engine')
+    db_username = data.get('db_username')
+    db_password = data.get('db_password')
     # Speichern der Typ-Synonyme, wenn vorhanden
     type_synonyms = data.get('type_synonyms')
     if type_synonyms:
@@ -323,7 +325,7 @@ def save_settings():
             return jsonify({'success': False, 'message': 'Fehler beim Speichern der Type Synonyms'})
     if db_url:
         connections = get_db_config()
-        connections.append({'url': db_url, 'name': db_name})
+        connections.append({'url': db_url, 'name': db_name, 'username': db_username, 'password': db_password})
         save_db_config(connections)
         return jsonify({'success': True})
     return jsonify({'success': False})

--- a/db_config.json
+++ b/db_config.json
@@ -1,1 +1,14 @@
-[{"url": "mongodb://localhost:27017", "name": "search_youtube"}, {"url": "mongodb://localhost:27017", "name": "search_engine"}]
+[
+  {
+    "url": "mongodb://localhost:27017",
+    "name": "search_youtube",
+    "username": "",
+    "password": ""
+  },
+  {
+    "url": "mongodb://localhost:27017",
+    "name": "search_engine",
+    "username": "",
+    "password": ""
+  }
+]

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -38,6 +38,14 @@
                 <input type="text" class="form-control" id="db-name" placeholder="Enter Database Name">
             </div>
             <div class="mb-3">
+                <label for="db-username" class="form-label">Database Username</label>
+                <input type="text" class="form-control" id="db-username" placeholder="Enter Database Username">
+            </div>
+            <div class="mb-3">
+                <label for="db-password" class="form-label">Database Password</label>
+                <input type="password" class="form-control" id="db-password" placeholder="Enter Database Password">
+            </div>
+            <div class="mb-3">
                 <label for="type-synonyms" class="form-label">Type Synonyms (JSON)</label>
                 <textarea class="form-control" id="type-synonyms" rows="4" placeholder='{"website": ["website", "webseite"]}'>{{ type_synonyms|safe }}</textarea>
                 <small class="form-text text-muted">
@@ -80,13 +88,15 @@
                 event.preventDefault();
                 const dbUrl = document.getElementById('db-url').value;
                 const dbName = document.getElementById('db-name').value;
+                const dbUsername = document.getElementById('db-username').value;
+                const dbPassword = document.getElementById('db-password').value;
                 const typeSynonyms = document.getElementById('type-synonyms').value;
                 fetch('/save-settings', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
                     },
-                    body: JSON.stringify({ db_url: dbUrl, db_name: dbName, type_synonyms: typeSynonyms }),
+                    body: JSON.stringify({ db_url: dbUrl, db_name: dbName, db_username: dbUsername, db_password: dbPassword, type_synonyms: typeSynonyms }),
                 })
                 .then(response => response.json())
                 .then(data => {


### PR DESCRIPTION
Add support for specifying a username and password for password-protected database connections.

* **app.py**
  - Update `MongoClient` initialization to use `username` and `password` from `db_config.json`.
  - Update `save_settings` function to save `username` and `password`.

* **db_config.json**
  - Add `username` and `password` fields to each database configuration.

* **templates/settings.html**
  - Add input fields for `username` and `password` in the settings form.
  - Update JavaScript to include `username` and `password` in the settings form submission.

* **README.md**
  - Update instructions to include `username` and `password` fields in the database configuration.
  - Add information about the updated settings page.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/search-engine/pull/29?shareId=ad63caab-f0d0-45c1-b871-7ccce7f6adb1).